### PR TITLE
fix: remove inaccurate comment

### DIFF
--- a/slides/weeksix/index.qmd
+++ b/slides/weeksix/index.qmd
@@ -370,7 +370,7 @@ print(f001(9))
 | Pop (from end of list)  | `L.pop()` | $1$ |
 | Pop (from index `i`)    | `L.pop(i)`	| $n - i$ |
 | Insert at index `i`     | `insert(i, newitem)` |	$n-i$ |
-| Delete an item (at index `i`) | `del(item)` |	$n - i$ |
+| Delete an item          | `del(item)` |	$n - i$ |
 | Membership testing      | `item in L` | $n$ |
 | Slice                   | `L[a:b]` | $b-a$
 | Concatenate two lists   | `L1 + L2` | $n_1 + n_2$ |


### PR DESCRIPTION
Deleting an item does not work with index, it takes an item. This is similar to how Append works, thus modifying the Operation Name value to match the pattern for Append.

https://www.w3schools.com/python/python_lists_remove.asp